### PR TITLE
Fixes the both dependency problem on a Mac

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,2 +1,4 @@
 [local]
 localhost ansible_connection=local
+[localhost]
+localhost ansible_python_interpreter=python


### PR DESCRIPTION
After installing boto, boto3 and ansible every run yielded error messages about boto not being available. Following https://www.zigg.com/2014/using-virtualenv-python-local-ansible.html I extended `hosts` which fixed the problem for me. 